### PR TITLE
Added SiPM data conversion as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "TBDataPreparation/FERS-5200-DataConverter"]
+	path = TBDataPreparation/FERS-5200-DataConverter
+	url = https://github.com/EdoPro98/FERS-5200-DataConverter.git


### PR DESCRIPTION
### FERS 5200 data converter
The code for the SiPM data conversion is added as a submodule.

This is to allow for external people to clone just the data conversion repository instead of the whole DREMTubes repo.

**SiPM data conversion code is has not been changed!**